### PR TITLE
forward sendCommand calls  to internal client

### DIFF
--- a/lib/disque.js
+++ b/lib/disque.js
@@ -12,12 +12,14 @@ function Disque(startupNodes, options) {
     lazyConnect: true,
     disqueNodes: startupNodes
   }));
+
   this.nodes = {};
   this.connect();
   var _this = this;
   this.on('connect', function () {
     _this.client.on('connect', function () {
       _this.stream = _this.client.stream;
+      _this.sendCommand = _this.client.sendCommand.bind(_this.client);
       _this.setStatus('ready');
       if (_this.offlineQueue.length) {
         debug('send %d commands in offline queue', _this.offlineQueue.length);


### PR DESCRIPTION
This resolves the issue mentioned in #2.

The problem was the wrapper Disque client wasn't forwarding calls to `sendCommand` to it's internal ioredis instance.
